### PR TITLE
[SE-3197] Updates Toggl API Base Url After Toggl became Toggl Track

### DIFF
--- a/libtoggl.py
+++ b/libtoggl.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S+00:00"
 ISSUE_REGEX = re.compile(r'[A-Z]{2,7}-\d{1,6}')
-TOGGL_API_BASE_URL = "https://www.toggl.com/api/v8/"
+TOGGL_API_BASE_URL = "https://api.track.toggl.com/api/v8/"
 TOGGL_TIMELOGS_URL = TOGGL_API_BASE_URL + "time_entries"
 
 


### PR DESCRIPTION
On September 7, 2020 Toggl became Toggl Track

Accordingly the API Url changes too, here's a reference to the new URL: https://github.com/toggl/toggl_api_docs/blob/master/toggl_api.md\#successful-requests

We want to add a link to showcase your repository on the [Onboarding Course's Logging Time](https://courses.opencraft.com/courses/course-v1:OpenCraft+onboarding+course/courseware/week_1/first_sprint/?activate_block_id=block-v1%3AOpenCraft%2Bonboarding%2Bcourse%2Btype%40sequential%2Bblock%40first_sprint). So this pull request is to update your repository to support Toggl Track :+1: 

**JIRA tickets**: SE-3197

**Testing instructions**:

Try recording some ticket with Toggl and push it onto Jira's Tempo

**Reviewers**
- [x] @giovannicimolin 