### PR TITLE
Fixes and safe checks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ requests==2.21.0
 six==1.12.0
 TogglPy==0.1.1
 traitlets==4.3.2
-typed-ast==1.3.5
+typed-ast==1.4.1
 urllib3==1.24.3
 wcwidth==0.1.7
 wrapt==1.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ astroid==2.2.5
 backcall==0.1.0
 certifi==2019.3.9
 chardet==3.0.4
+click==7.1.2
 decorator==4.4.0
 idna==2.8
 ipdb==0.12

--- a/sync_timelogs.py
+++ b/sync_timelogs.py
@@ -71,6 +71,7 @@ if __name__ == '__main__':
    argp.add_argument('-n', action='store_true', help='Make no modifications')
    argp.add_argument('-v', action='store_true', help='Be verbose')
    argp.add_argument('-s', action='store', default=None, help='Starting date, e.g. 2019-01-01')
+   argp.add_argument('-e', action='store', default=None, help='End date, e.g. 2019-01-01')
    args = argp.parse_args()
 
    # Verbosity, needs work
@@ -87,8 +88,11 @@ if __name__ == '__main__':
             start = datetime.fromtimestamp(float(f.read()))
       except:
          print('ERROR: .latest not found, run with "-s YYYY-MM-DD"')
-   # Set end to last midnight
-   end = datetime.now().replace(hour=0, minute=0, second=0)
+   if args.e:
+      end = datetime.strptime(args.e, r'%Y-%m-%d')
+   else:
+      # Set end to last midnight
+      end = datetime.now().replace(hour=0, minute=0, second=0)
 
    # Fetch complete and incomplete timelogs
    complete, incomplete = get_timelogs(start, end)

--- a/sync_timelogs.py
+++ b/sync_timelogs.py
@@ -2,6 +2,7 @@
 import argparse
 import sys
 
+import click
 from datetime import datetime, timedelta, timezone
 from dateutil import parser
 from decouple import config
@@ -32,8 +33,6 @@ def update_tempo(timelogs, logf):
    for timelog in grouped:
       logf("Logging time for {}: {} ({}) ({})".format(
          timelog.ticket, timelog.description, timelog.date, timelog.time))
-      if args.n:
-         continue
       if not tempo_driver.add_timelog(timelog):
          print("Unable to log time for {}".format(timelog.ticket))
          # TODO: This will fail, fix
@@ -108,11 +107,11 @@ if __name__ == '__main__':
       sys.exit(1)
 
    # This will update Tempo
-   last = update_tempo(grouped, logf)
-   if last:
-      # Stopped before everything was processed
-      end = last
+   if not args.n and click.confirm('\nDo you want to upload these worklogs to Tempo?', default=False):
+      last = update_tempo(grouped, logf)
+      if last:
+         # Stopped before everything was processed
+         end = last
 
-   if not args.n:
       with open('.latest', 'w') as f:
          f.write(str(end.timestamp()))


### PR DESCRIPTION
This:
1. Fixes `typed-ast` version that is breaking requirements installation in Python 3.8.
1. Adds an `-e` option to specify end date.
1. Adds a confirmation prompt before uploading worklogs, with an example scenario mentioned in the commit message. If you're running this via the cronjob, we could also add a `-y` option that would bypass it.