### PR TITLE
Improve stripping ticket from description

### DIFF
--- a/libtoggl.py
+++ b/libtoggl.py
@@ -78,7 +78,8 @@ class TogglTimesheets:
             if possible:
                 # TODO Dividing to multiple tickets
                 ticket = possible[0]
-                raw["description"] = raw["description"].strip(ticket).strip()
+                desc = re.sub(r'\[?%s\]?' % ticket, '', raw["description"])
+                raw["description"] = desc.strip()
 
         if "description" not in raw:
             # Shouldn't exist, but alas


### PR DESCRIPTION
`str.strip('chars')` is less than ideal for stripping the ticket from the description, because it will also strip any of the given `chars` from either the beginning or end of the string.

Use `re.sub()` instead, while also stripping possible '[]' markers from around the ticket match.