### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,10 @@ decorator==4.4.0
 idna==2.8
 python-dateutil==2.8.0
 python-decouple==3.1
-requests==2.21.0
+requests==2.25.1
 six==1.15.0
-TogglPy==0.1.1
+TogglPy==0.1.2
 traitlets==4.3.2
 typed-ast==1.4.1
-urllib3==1.26.5
-black==20.8b1
+urllib3==1.26.6
+black==21.6b0


### PR DESCRIPTION
- `TogglPy==0.1.2` updates the Toggl API URL. The old one should be dropped after June 30th, 2021.
- `requests==2.21.0` could not be installed with `urllib3==1.26.5`.