### PR TITLE
feat: Better error reporting

### DIFF
--- a/libtempo.py
+++ b/libtempo.py
@@ -107,7 +107,11 @@ class JiraTempoTimelogsDriver:
         response = self.session.post(
             self.get_url("worklogs") + timelog.ticket, data=payload
         )
+        response_details = response.content.decode("UTF-8")
 
-        if 'valid="true"' in response.content.decode("UTF-8"):
+        if 'valid="true"' in response_details:
             return True
-        return False
+        else:
+            raise RuntimeError(
+                f"Unable to log time entry on {timelog.ticket} - see response from tempo: \n {response_details}"
+            )

--- a/sync_timelogs.py
+++ b/sync_timelogs.py
@@ -43,10 +43,7 @@ def update_tempo(timelogs, logf):
                 timelog.ticket, timelog.description, timelog.date, timelog.time
             )
         )
-        if not tempo_driver.add_timelog(timelog):
-            print("Unable to log time for {}".format(timelog.ticket))
-            # TODO: This will fail, fix
-            return parser.parse(timelog.date).timestamp()
+        tempo_driver.add_timelog(timelog)
 
 
 def group_timelogs(timelogs, logf):


### PR DESCRIPTION
Submitting a PR with changes that I made a long time ago...

This addresses a TODO item in the script.

Before: if Tempo returns an error response, often all you'll see is an error about being unable to parse a date.

Now: if Tempo returns an error response, it will be reported to the user, including a mention of which ticket caused the issue.