### PR TITLE
fix: remove duronly check

### DIFF
--- a/libtoggl.py
+++ b/libtoggl.py
@@ -56,12 +56,10 @@ class TogglTimesheets:
             'stop': '2019-05-11T12:40:27+00:00',
             'description': 'Trying to deploy mongodb',
             'tags': ['BB-1212'],
-            'duronly': False,
+            # this field is deprecated for GET endpoints and always true
+            'duronly': True,
         }
         """
-        if raw.get("duronly", False):
-            raise ("Error, timelog with duronly = true")
-
         tags = raw.get("tags", [])
         ticket = None
         dd = False


### PR DESCRIPTION
Fixes this:
```python
Traceback (most recent call last):
  File "/home/demid/Soft/toggl-tempo-worklog-transfer/sync_timelogs.py", line 124, in <module>
    complete, incomplete = get_timelogs(start, end)
  File "/home/demid/Soft/toggl-tempo-worklog-transfer/sync_timelogs.py", line 83, in get_timelogs
    timelogs = toggl_driver.get_timelogs(start, end)
  File "/home/demid/Soft/toggl-tempo-worklog-transfer/libtoggl.py", line 146, in get_timelogs
    timelog = self._parse_timelog(item)
  File "/home/demid/Soft/toggl-tempo-worklog-transfer/libtoggl.py", line 72, in _parse_timelog
    raise ("Error, timelog with duronly = true")
TypeError: exceptions must derive from BaseException
```

Details [here](https://developers.track.toggl.com/docs/api/time_entries/index.html):
```json
"duronly": {
    "description": "Used to create a TE with a duration but without a stop time, this field is deprecated for GET endpoints where the value will always be true.",
    "type": "boolean"
},
```